### PR TITLE
remove user's home directory path from version-controlled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /build
 /captures
 .externalNativeBuild
+local.properties
 
 # Lines starting with `#` are comments.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
+    ndkVersion "21.1.6352462"
     defaultConfig {
         applicationId "humer.uvc_camera"
         targetSdkVersion 30
@@ -133,16 +134,12 @@ tasks.withType(JavaCompile) {
 }
 
 String getNdkBuildPath() {
-    Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-    def ndkBuildingDir = properties.getProperty("ndk.dir")
-    def ndkBuildPath = ndkBuildingDir
+    def ndkBuildingDir = project.android.ndkDirectory.path
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        ndkBuildPath = ndkBuildingDir + '/ndk-build.cmd'
+        return ndkBuildingDir + '/ndk-build.cmd'
     } else {
-        ndkBuildPath = ndkBuildingDir + '/ndk-build'
+        return ndkBuildingDir + '/ndk-build'
     }
-    return ndkBuildPath
 }
 
 task ndkBuild(type: Exec, description: 'Compile JNI source via NDK') {

--- a/app/src/main/jni/libUvc_Support/libuvc_support.h
+++ b/app/src/main/jni/libUvc_Support/libuvc_support.h
@@ -22,8 +22,7 @@ This Repository is provided "as is", without warranties of any kind.
 
 #ifndef libuvc_support_h__
 #define libuvc_support_h__
-#include </home/peter/Android/Sdk/ndk/21.1.6352462/sysroot/usr/include/android/native_window.h>
-#include </home/peter/Android/Sdk/ndk/21.1.6352462/sysroot/usr/include/jni.h>
+#include <jni.h>
 #include <libusb.h>
 #include <pthread.h>
 

--- a/local.properties
+++ b/local.properties
@@ -1,9 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Mar 03 21:16:02 CET 2020
-sdk.dir=/home/peter/Android/Sdk
-ndk.dir=/home/peter/Android/Sdk/ndk/21.1.6352462


### PR DESCRIPTION
I found that some files contain the path of the user's home directory and this requires each user to edit those files manually. So I made changes to put the user home directory out of the version-controlled files. This would allow each user who clones the repo to build the project without editing files locally. I confirmed that the build passes on Linux and Windows.

- I deleted ```local.properties```; a quick google search suggested that this file should not be committed to the repo and I confirmed that Android Studio generates the file and automatically fills it with the user's SDK directory path (sdk.dir).
- The auto-generated ```local.properties``` will only contain ```sdk.dir``` and not ```ndk.dir```, but this is fine as Android Studio says that ```ndk.dir``` is deprecated now and ```android.ndkDirectory``` should be used instead, so I changed ```app/build.gradle``` accordingly as well.
- In ```libuvc_support.h```, ```native_window.h``` was included twice so I deleted the one with the home directory path. It seems that ```jni.h``` is correctly included simply as ```<jni.h>``` so I changed this too.
